### PR TITLE
Add sample React Native app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# codex-test
+# Codex Test Repository
+
+This repository contains a sample React Native (Expo) project under `sample-app/`.
+The app demonstrates a simple apparel e-commerce application that works on both
+iOS and Android. It includes GPS tracking via Expo Location and Google Analytics
+integration via Firebase Analytics.
+

--- a/sample-app/App.js
+++ b/sample-app/App.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
+import * as Location from 'expo-location';
+import * as Analytics from 'expo-firebase-analytics';
+
+const categories = [
+  { name: 'Men', products: Array.from({length: 10}, (_, i) => `Men Item ${i+1}`) },
+  { name: 'Women', products: Array.from({length: 10}, (_, i) => `Women Item ${i+1}`) },
+  { name: 'Kids', products: Array.from({length: 10}, (_, i) => `Kids Item ${i+1}`) },
+  { name: 'Accessories', products: Array.from({length: 10}, (_, i) => `Accessory Item ${i+1}`) }
+];
+
+const articles = Array.from({length: 5}, (_, i) => `Reading Content ${i+1}`);
+
+export default function App() {
+  const [location, setLocation] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        console.warn('Permission to access location was denied');
+        return;
+      }
+      let loc = await Location.getCurrentPositionAsync({});
+      setLocation(loc);
+      Analytics.logEvent('location_obtained', {
+        latitude: loc.coords.latitude,
+        longitude: loc.coords.longitude
+      });
+    })();
+  }, []);
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.header}>Apparel EC Sample</Text>
+      <Text style={styles.subHeader}>Articles</Text>
+      {articles.map((a, idx) => (
+        <Text key={idx} style={styles.article}>{a}</Text>
+      ))}
+      {categories.map((cat, idx) => (
+        <View key={idx} style={styles.category}>
+          <Text style={styles.categoryTitle}>{cat.name}</Text>
+          {cat.products.map((p, i) => (
+            <Text key={i} style={styles.product}>{p}</Text>
+          ))}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10
+  },
+  subHeader: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 10
+  },
+  article: {
+    marginVertical: 4
+  },
+  category: {
+    marginTop: 20
+  },
+  categoryTitle: {
+    fontSize: 18,
+    fontWeight: 'bold'
+  },
+  product: {
+    marginLeft: 10,
+    marginVertical: 2
+  }
+});

--- a/sample-app/README.md
+++ b/sample-app/README.md
@@ -1,0 +1,26 @@
+# Sample Apparel EC App
+
+This directory contains a minimal React Native (Expo) sample for an apparel e-commerce app. It demonstrates:
+
+- Common codebase for iOS and Android.
+- Fetching the user's GPS location using `expo-location`.
+- Logging events to Google Analytics with `expo-firebase-analytics`.
+- Four product categories with ten sample items each.
+- Five articles displayed at the top of the app.
+
+## Getting Started
+
+1. Install Expo CLI:
+   ```bash
+   npm install -g expo-cli
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the app:
+   ```bash
+   expo start
+   ```
+
+You'll need Firebase Analytics configured for your project to send analytics events.

--- a/sample-app/package.json
+++ b/sample-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sample-app",
+  "version": "1.0.0",
+  "main": "App.js",
+  "private": true,
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "expo-firebase-analytics": "~8.0.0",
+    "expo-location": "~15.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add React Native (Expo) sample app with GPS and Google Analytics
- document how to run the app
- clean up root README

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_68518966e3688331b166f82a965aa953